### PR TITLE
BREAKING CHANGE: Update checkov to v3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
 
     - name: Test with Checkov
       id: checkov
-      uses: bridgecrewio/checkov-action@v12.2527.0 
+      uses: bridgecrewio/checkov-action@v12
       with:
         directory: ${{ inputs.checkov_dir }}
         framework: terraform


### PR DESCRIPTION
Running this action yields a deprecation warning from 2022:

> DNS / Plan Cloud Infrastructure
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

The issue was reported & resolved in https://github.com/bridgecrewio/checkov-action/issues/105. 

The recommended way to use the action is to specify only the major version (12) so we pick up fixes as they're released, so this change removes the build version pinning. This will resolve the deprecation issue by pulling in a new version (2 years newer)

### Considerations

1. This will bump Checkov from v2 to v3. The [migration guide](https://github.com/bridgecrewio/checkov/blob/main/docs/1.Welcome/Migration.md) looks like it'll be fine for our use case, but it's worth checking.

### After merge

If this PR is merged, we'll need to update the projects that use this action: https://github.com/search?q=org%3ALBHackney-IT+LBHackney-IT%2Fterraform-action&type=code