### PR TITLE
feat: updating destroy flag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -124,7 +124,7 @@ runs:
 
     - name: Terraform Destroy
       if:  inputs.destroy == 'true'
-      run: terraform destroy auto-approve
+      run: terraform destroy -auto-approve
       shell: bash   
 
     - name: Terraform Apply


### PR DESCRIPTION
I have raised this PR in response to this error in the destroy-test-repo:

 Error: Failed to load "auto-approve" as a plan file
│ 
│ Error: stat auto-approve: no such file or directory

I believe I missed a '-' with this auto-approve. 