### PR TITLE
feat!: pass in vars_file to destroy command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -124,7 +124,7 @@ runs:
 
     - name: Terraform Destroy
       if:  inputs.destroy == 'true'
-      run: terraform destroy -auto-approve
+      run: terraform destroy -var-file='${{ inputs.vars_file }}' -input=false -no-color -auto-approve
       shell: bash   
 
     - name: Terraform Apply


### PR DESCRIPTION
This PR adds  input=false to disable interactive commands and also passes in the vars_file to to the destroy step. 