### PR TITLE
feat: updating terraform plan step in action.yml to use outfile

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,6 @@ runs:
         directory: ${{ inputs.checkov_dir }}
         framework: terraform
         soft_fail: false
-        hard_fail_on: MEDIUM
 
   # Checks that all Terraform configuration files adhere to a canonical format
     - name: Terraform Format

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ runs:
     - name: Terraform Plan
       id: plan
       if: inputs.plan == 'true'
-      run: terraform plan -var-file='${{ inputs.vars_file }}' -var="repository_id=${{ github.repository_id }}" -var="repository=${{ github.repository }}" -input=false -no-color
+      run: terraform plan -var-file='${{ inputs.vars_file }}' -var="repository_id=${{ github.repository_id }}" -var="repository=${{ github.repository }}" -input=false -no-color -out=tfplan
       continue-on-error: true
       shell: bash
       working-directory: ${{ inputs.directory }}

--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,8 @@ runs:
       with:
         directory: ${{ inputs.checkov_dir }}
         framework: terraform
-        check: MEDIUM
+        soft_fail: false
+        hard_fail_on: MEDIUM
 
   # Checks that all Terraform configuration files adhere to a canonical format
     - name: Terraform Format

--- a/action.yml
+++ b/action.yml
@@ -144,6 +144,6 @@ runs:
 
     - name: Terraform Apply
       if: inputs.apply == 'true' && github.event_name != 'pull_request'
-      run: terraform apply -var-file='${{ inputs.vars_file }}' -var="repository_id=${{ github.repository_id }}" -var="repository=${{ github.repository }}" -input=false -no-color -auto-approve
+      run: terraform apply -input=false -no-color -auto-approve tfplan
       shell: bash
       working-directory: ${{ inputs.directory }}


### PR DESCRIPTION
This PR does the following, as per [CE-3052](https://hackney.atlassian.net/browse/CE-3052):

**Checkov**:

- Replaces `check: MEDIUM` with `soft_fail: false` to ensure failed Checkov findings fail the workflow (example [here](https://github.com/LBHackney-IT/ce-aft-infrastructure/actions/runs/24675036318/job/72156434802))

**Terraform Plan**:

- Updates the plan step to use `-out=tfplan` which produces a saved Terraform Plan file that can be reused by a later apply step

**Terraform Apply**:

- Updates the apply step to consume the saved tfplan file instead of recalculating from configuration at deploy time (example [here](https://github.com/LBHackney-IT/aws-user-permissions/actions/runs/24511113098/job/71642487355#step:5:21))
- Removed plan time variables as I don't believe they are necessary and are already captured in the saved plan

[CE-3052]: https://hackney.atlassian.net/browse/CE-3052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ